### PR TITLE
Fix the "GE" problem

### DIFF
--- a/app.js
+++ b/app.js
@@ -45,7 +45,7 @@ connection.on('connect', function(err) {
     // If no error, then good to proceed.
     
         if (err) {
-        //    console.log(err);
+            console.log(err);
             arrayErr.push(err);
         } else {
           console.log("Connected to " + this.config.server + " " + this.config.options.database);
@@ -61,6 +61,7 @@ connection.on('connect', function(err) {
  function loadMappingArray() {
       
         request = new Request("SELECT Title, AssignedTE, AssignedBE FROM dbo.PartnerIsvs", function(err) {
+        console.log('loadMappingArray');
          if (err) {
             console.log(err);
             arrayErr.push(err);
@@ -132,28 +133,29 @@ dialog.matches('Find_TE', [
 
     }
     ,
+
+//===============================Beginning of Find TE==========================    
     function (session, results) {
         var searchAccount = "";
         var account = results.response;
         console.log('in lookup function, account = ' + account);
         //create regex version of the searchAccount
         if (!account) {
-                // console.log("Sorry, I couldn't make out the name of the account you are looking for.");
+                 console.log("Sorry, I couldn't make out the name of the account you are looking for.");
                 builder.prompts.text(session, "Sorry, I couldn't make out the name of the account you are looking for.");
         } else { 
-                (searchAccount = new RegExp(account, 'i'))
-
+                 searchAccount = new RegExp("\\b" + account+ "\\b", 'i');
         //search mapping array for searchAccount
         var x = 0;
         var found = false;
                 // Next line to assist with debugging
-                // // console.log("Looking for account");
+                 console.log("Looking for account " + searchAccount);
         while ( x < arrayIsvTE.length) {
             if (arrayIsvTE[x].match(searchAccount)) {
             //post results to chat
                 if(arrayIsvTE[x+1]) {
-                    // var msg = "The TE for " + arrayIsvTE[x] + " is " + arrayIsvTE[x+1];
-                    // console.log( msg); 
+                    var msg = "The TE for " + arrayIsvTE[x] + " is " + arrayIsvTE[x+1];
+                    console.log( msg); 
                     session.send("The TE for " + arrayIsvTE[x] + " is " + arrayIsvTE[x+1]);
                     found = true;
                     }
@@ -176,6 +178,7 @@ dialog.matches('Find_TE', [
 ]);
 //===============================End of Find TE==========================
 
+//===============================Beginning of Find BE====================
 dialog.matches('Find_BE', [
     function (session, args, next) {
         console.log('Find_BE called');
@@ -209,7 +212,7 @@ dialog.matches('Find_BE', [
                 // console.log("Sorry, I couldn't make out the name of the account you are looking for.");
                 builder.prompts.text(session, "Sorry, I couldn't make out the name of the account you are looking for.");
         } else { 
-                (searchAccount = new RegExp(account, 'i'))
+                (searchAccount = new RegExp("\\b" + account+ "\\b", 'i'))
 
         //search mapping array for searchAccount
         var x = 0;
@@ -243,6 +246,8 @@ dialog.matches('Find_BE', [
     }
 ]);
 //===============================End of Find BE==========================
+
+//===============================Beginning of Find Accounts==============
 
 dialog.matches('Find_Accounts', [function (session, args, next) { 
     //handle the case where intent is List Accounts for BE or TE
@@ -296,12 +301,9 @@ dialog.matches('Find_Accounts', [function (session, args, next) {
             }
         }]);   
 
-
-
-
-
-
 //===============================End of Find Accounts==========================
+
+//===============================Beginning of Find Both========================
 
 dialog.matches('Find_Both', [function (session, args, next) { 
         //    console.log(args.entities); 
@@ -316,13 +318,14 @@ dialog.matches('Find_Both', [function (session, args, next) {
         if (!accountEntity) {
                 session.send("Sorry, I couldn't make out the name of the account you are looking for.");
         } else { 
-                (searchAccount = new RegExp(accountEntity.entity, 'i'))
+                (searchAccount = new RegExp("\\b" + accountEntity.entity + "\\b", 'i'))
 
                 // Next line to assist with debugging
                 // session.send( "Looking for the TE for " + searchAccount); 
 
                 //search mapping array for searchAccount
                 var x = 0;
+
                 var found = false;
                         // Next line to assist with debugging
                         // // console.log("Looking for account");

--- a/app.js
+++ b/app.js
@@ -45,7 +45,7 @@ connection.on('connect', function(err) {
     // If no error, then good to proceed.
     
         if (err) {
-            console.log(err);
+        //    console.log(err);
             arrayErr.push(err);
         } else {
           console.log("Connected to " + this.config.server + " " + this.config.options.database);
@@ -61,7 +61,7 @@ connection.on('connect', function(err) {
  function loadMappingArray() {
       
         request = new Request("SELECT Title, AssignedTE, AssignedBE FROM dbo.PartnerIsvs", function(err) {
-        console.log('loadMappingArray');
+
          if (err) {
             console.log(err);
             arrayErr.push(err);
@@ -141,7 +141,7 @@ dialog.matches('Find_TE', [
         console.log('in lookup function, account = ' + account);
         //create regex version of the searchAccount
         if (!account) {
-                 console.log("Sorry, I couldn't make out the name of the account you are looking for.");
+                // console.log("Sorry, I couldn't make out the name of the account you are looking for.");
                 builder.prompts.text(session, "Sorry, I couldn't make out the name of the account you are looking for.");
         } else { 
                  searchAccount = new RegExp("\\b" + account+ "\\b", 'i');
@@ -149,13 +149,13 @@ dialog.matches('Find_TE', [
         var x = 0;
         var found = false;
                 // Next line to assist with debugging
-                 console.log("Looking for account " + searchAccount);
+                // console.log("Looking for account " + searchAccount);
         while ( x < arrayIsvTE.length) {
             if (arrayIsvTE[x].match(searchAccount)) {
             //post results to chat
                 if(arrayIsvTE[x+1]) {
-                    var msg = "The TE for " + arrayIsvTE[x] + " is " + arrayIsvTE[x+1];
-                    console.log( msg); 
+                    // var msg = "The TE for " + arrayIsvTE[x] + " is " + arrayIsvTE[x+1];
+                    // console.log( msg); 
                     session.send("The TE for " + arrayIsvTE[x] + " is " + arrayIsvTE[x+1]);
                     found = true;
                     }


### PR DESCRIPTION
Tom, this update adds the "word" metacharacter to the regex testing for accounts for FindTE, FindBE, and FindBoth.  If you search for owners of GE now, you'll get back responses for GE, GE Healthcare, and GE Oil and Gas but will no longer get results like "Orange."  My plan is to add a carousel with the results with detailed info on each and let you choose which one you'd like to take further action it (things like getting more info or emailing the TE or BE).

Let me know if you have questions...

Ron