### PR TITLE
Need to remove the old x++ times 3 looping mechanism of Tom's in FindBE

### DIFF
--- a/app.js
+++ b/app.js
@@ -288,9 +288,6 @@ dialog.matches('Find_BE', [
                     found = true;
                     }
                 };
-            x++;
-            x++;
-            x++;
             };
             if (!found) {
 


### PR DESCRIPTION
Tom's original looping used 3 "x++" statements in a row to move through the flat array he created.  When I moved to an array of account objects, this was no longer required.  Somehow I missed removing these from the Find_BE dlg resulting in not being able to find some BEs.  This fixes that bug.