### PR TITLE
Ronharper

### DIFF
--- a/app.js
+++ b/app.js
@@ -103,7 +103,7 @@ function DisplayTEBECard (session, accountInfo, BEorTE){
                 .text("Alias: " + whichAlias +  "\n" + "Location: " + whichLocation)
                 .buttons([
                     builder.CardAction.openUrl(session, "mailto:" + whichAlias + "@microsoft.com", "Email " + whichOwner),
-                    builder.CardAction.postBack(session, "which accounts does " + whichOwner + " own?", "foo", "which accounts does " + whichOwner + " own?"),
+                    builder.CardAction.postBack(session, "Which accounts does " + whichOwner + " own?", "Which accounts does " + whichOwner + " own?"),
                     builder.CardAction.postBack(session, srchStr + " for " + accountInfo.Title, srchStr2 + " for " + accountInfo.Title + "?")
                 ])
         ]);

--- a/app.js
+++ b/app.js
@@ -103,7 +103,7 @@ function DisplayTEBECard (session, accountInfo, BEorTE){
                 .text("Alias: " + whichAlias +  "\n" + "Location: " + whichLocation)
                 .buttons([
                     builder.CardAction.openUrl(session, "mailto:" + whichAlias + "@microsoft.com", "Email " + whichOwner),
-                    builder.CardAction.postBack(session, "which accounts does " + whichOwner + " own?", "Other Accounts", "which accounts does " + whichOwner + " own?"),
+                    builder.CardAction.postBack(session, "which accounts does " + whichOwner + " own?", "foo", "which accounts does " + whichOwner + " own?"),
                     builder.CardAction.postBack(session, srchStr + " for " + accountInfo.Title, srchStr2 + " for " + accountInfo.Title + "?")
                 ])
         ]);

--- a/app.js
+++ b/app.js
@@ -103,7 +103,7 @@ function DisplayTEBECard (session, accountInfo, BEorTE){
                 .text("Alias: " + whichAlias +  "\n" + "Location: " + whichLocation)
                 .buttons([
                     builder.CardAction.openUrl(session, "mailto:" + whichAlias + "@microsoft.com", "Email " + whichOwner),
-                    builder.CardAction.postBack(session, "which accounts does " + whichOwner + " own?", "Other Accounts", "Other Accounts"),
+                    builder.CardAction.postBack(session, "which accounts does " + whichOwner + " own?", "Other Accounts", "which accounts does " + whichOwner + " own?"),
                     builder.CardAction.postBack(session, srchStr + " for " + accountInfo.Title, srchStr2 + " for " + accountInfo.Title + "?")
                 ])
         ]);


### PR DESCRIPTION
Update to make the "Other Accounts" button work in the TE/BE card in Microsoft Teams.  Sadly, Teams currently only works if you use the exact text of the message you send back to the bot as the text on the button.  Supposed to be separate as it is in the emulator and in skype.  So, for now, text on button will be the clunky full query of "Which accounts does <person> own?" so the query works.